### PR TITLE
Using Codecs.encode instead of .encode('hex')

### DIFF
--- a/libs/SmartMeshSDK/utils/JsonManager.py
+++ b/libs/SmartMeshSDK/utils/JsonManager.py
@@ -12,6 +12,7 @@ import threading
 import copy
 import pickle
 import traceback
+import codecs
 from future.utils import iteritems
 from builtins import str as text
 if os.name=='nt':       # Windows
@@ -887,7 +888,7 @@ class JsonManager(object):
             elif v==[]:
                 fields[n]         = v
             else:
-                fields[n]         = int(''.join([chr(b) for b in v]).encode('hex'), 16)
+                fields[n]         = int(codecs.encode(bytes(''.join([chr(b) for b in v]), 'utf-8'), 'hex'), 16)
         returnVal['fields']       = fields
         return returnVal
     


### PR DESCRIPTION
The .encode('hex') function expects a bytes-like object, but it was receiving a string instead. 
Codecs.encode can handle arbitrary codecs, e.g. to encode a string representation of binary data into hexadecimal format, 
which then was used to convert the string into an integer. 
(bug appeared in lab 22 of Dust academy labs https://dustcloud.atlassian.net/wiki/spaces/ALLDOC/pages/40468792/Lab+22.+OAP+GPIO+get) 

