### PR TITLE
Fix OTAP protocol files

### DIFF
--- a/libs/SmartMeshSDK/protocols/otap/GenStructs.py
+++ b/libs/SmartMeshSDK/protocols/otap/GenStructs.py
@@ -35,7 +35,7 @@ def parse_field(field, data, index = 0):
         val = struct.unpack('!H', data[s:e])[0]
     elif field.type is 'int' and field.len is 4:
         try:
-        val = struct.unpack('!L', data[s:e])[0]
+            val = struct.unpack('!L', data[s:e])[0]
         except TypeError:
             aByte = data[s]
             anInt = data[s:e]

--- a/libs/SmartMeshSDK/protocols/otap/OTAPCommunicator.py
+++ b/libs/SmartMeshSDK/protocols/otap/OTAPCommunicator.py
@@ -241,6 +241,13 @@ class OTAPCommunicator(object):
         log.info('Got Status response from %s' % print_mac(mac))
         log.debug('Data: ' + ' '.join(['%02X' % ord(b) for b in cmd_data]))
         os_resp = OtapStatusResp()
+
+        if isinstance(cmd_data, str):
+            # convert the str to bytes using latin-1, because all Unicode codepoints from 0x00 through to 0xFF
+            # are mapped one-on-one to bytes with the same value.
+            # This is equivalent to: `cmd_data = bytearray(map(ord, cmd_data))`
+            cmd_data = cmd_data.encode('latin-1')
+
         os_resp.parse(cmd_data)
         log.debug(str(os_resp))
 

--- a/libs/SmartMeshSDK/protocols/otap/OTAPMic.py
+++ b/libs/SmartMeshSDK/protocols/otap/OTAPMic.py
@@ -66,16 +66,16 @@ crctab = [
       0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78 ]
 
 def calcFCS(msg):
-   fcs = 0xffff
-   
-   for b in msg:
-      try:
-      c = struct.unpack('B', b)[0]
-      except TypeError:
-          c = struct.unpack('B', bytes([b]))[0]
-      fcs = (fcs >> 8) ^ crctab[(fcs ^ c) & 0xff]
+    fcs = 0xffff
 
-   return ~fcs & 0xFFFF
+    for b in msg:
+        try:
+            c = struct.unpack('B', b)[0]
+        except TypeError:
+            c = struct.unpack('B', bytes([b]))[0]
+        fcs = (fcs >> 8) ^ crctab[(fcs ^ c) & 0xff]
+
+    return ~fcs & 0xFFFF
 
 
 def getFCS(msg):


### PR DESCRIPTION
This adds missing indentations which resulted in a `IndentationError: expected an indented block after 'try' statement on line X` when running `python OTAPCommunicator.py ...`

This also add a missing `str` to `bytes` conversion when fetching the missing packets from mote.